### PR TITLE
Added id to example

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -84,6 +84,9 @@ impl ksni::Tray for MyTray {
             .into(),
         ]
     }
+    fn id(&self) -> String {
+        "mytray".to_string()
+    }
 }
 
 fn main() {


### PR DESCRIPTION
It is necessary for some implementations of the StatusNotifierItem spec.
And can lead to it not displaying any icon without any apparent error.