### PR TITLE
Accept FnOnce in Handle::update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub type State<T> = Handle<T>;
 
 impl<T: Tray> Handle<T> {
     /// Update the tray
-    pub fn update<F: Fn(&mut T)>(&self, f: F) {
+    pub fn update<F: FnMut(&mut T)>(&self, mut f: F) {
         {
             let mut model = self.model.lock().unwrap();
             (f)(&mut model);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub type State<T> = Handle<T>;
 
 impl<T: Tray> Handle<T> {
     /// Update the tray
-    pub fn update<F: FnMut(&mut T)>(&self, mut f: F) {
+    pub fn update<F: FnOnce(&mut T)>(&self, f: F) {
         {
             let mut model = self.model.lock().unwrap();
             (f)(&mut model);


### PR DESCRIPTION
This allows closures that capture local variables mutably,
allowing more freedom when reacting to state changes in the Tray.