### PR TITLE
Handle::update: Return the return value of the callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,12 +173,10 @@ pub type State<T> = Handle<T>;
 
 impl<T: Tray> Handle<T> {
     /// Update the tray
-    pub fn update<F: FnOnce(&mut T)>(&self, f: F) {
-        {
-            let mut model = self.model.lock().unwrap();
-            (f)(&mut model);
-        }
+    pub fn update<R, F: FnOnce(&mut T) -> R>(&self, f: F) -> R {
+        let ret = f(&mut self.model.lock().unwrap());
         self.tray_status.need_update();
+        ret
     }
 
     /// Shutdown the tray service


### PR DESCRIPTION
This allows callers of update to initialize variables
computed in the closure.

An example use case is the following pattern:

```Rust
let event_flags = app.tray_handle.update(|tray: &mut AppTray| {
	app.write_tray_info(&mut tray.app_state.tray_info);
	tray.app_state.paused = app.paused_or_stopped();
	tray.event_flags.take()
});
if event_flags.quit_clicked {
	break;
}
if event_flags.activated {
	win_visible ^= true;
	rw.set_visible(win_visible);
}
...
```