### PR TITLE
Add 'id' function into example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ impl ksni::Tray for MyTray {
     fn title(&self) -> String {
         if self.checked { "CHECKED!" } else { "MyTray" }.into()
     }
+    fn id(&self) -> String {
+        "com.example.MyApplicationId".into()
+    }
     fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
         use ksni::menu::*;
         vec![


### PR DESCRIPTION
The 'id' function was previously missing in the example, but it's needed in order for the menu to pop up on Ubuntu-based distros (I'm not sure if other distros are affected, I just run Ubuntu and know it's affecting at least Ubuntu 22.10/23.04).

The only reason I knew that adding the 'fn id()' call would fix the issue is because of https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/320, but I think having an ID listed by default would be a good idea - I can't see any downsides to it anyway.