### PR TITLE
don't depend on zbus tokio feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Unlicense"
 [features]
 default = ["tokio"]
 blocking = ["dep:once_cell"]
-tokio = ["dep:tokio", "zbus/tokio"]
+tokio = ["dep:tokio"]
 async-io = [
     "dep:async-io",
     "dep:async-lock",
@@ -29,10 +29,10 @@ async-io = [
 [dependencies]
 paste = "1"
 futures-util = "0.3"
-zbus = { version = "5", default-features = false }
+zbus = { version = "5", default-features = false, features = ["async-io"] }
 serde = { version = "1", features = ["derive"] }
 
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "macros", "sync", "time"], optional = true }
 
 async-io = { version = "2", optional = true }
 async-lock = { version = "3", optional = true }


### PR DESCRIPTION
enabling the zbus tokio feature breaks zbus usage in non-tokio projects, see also https://github.com/AccessKit/accesskit/issues/515 and https://github.com/AccessKit/accesskit/issues/227#issuecomment-1540928475

zbus is still compatible with tokio without that feature, you just need to follow the `.internal_executor(false)` approach you were already using for async-io