### PR TITLE
StatusNotifierWatcherProxy fails under Snap confinement due to GetAll D-Bus call

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -70,7 +70,9 @@ pub(crate) async fn run<T: Tray>(
             .to_string()
     };
 
-    let snw_object = StatusNotifierWatcherProxy::new(&conn)
+    let snw_object = StatusNotifierWatcherProxy::builder(&conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
+        .build()
         .await
         .expect("macro generated dbus Proxy should be valid");
 


### PR DESCRIPTION
### Problem
When running inside a Snap package, `StatusNotifierWatcherProxy::new(&conn)` fails because
it implicitly calls `org.freedesktop.DBus.Properties.GetAll` on `org.kde.StatusNotifierWatcher`.
Snap's AppArmor policy blocks `GetAll` on interfaces the application does not own, causing
a D-Bus error and preventing tray icon registration.
### Environment
- Snap strict confinement on Ubuntu 24.04+
- GNOME Shell with AppIndicator extension
- ksni 0.3.3, zbus 5.x
### Fix
Replace `StatusNotifierWatcherProxy::new()` with the builder pattern using
`cache_properties(CacheProperties::No)` to prevent bulk property fetching.
Individual property getters still work because `Get` calls are permitted by AppArmor.
### Impact
- No behavioral change for non-sandboxed environments
- Fixes Snap tray icon registration without requiring `confinement: classic`
- Follows documented zbus patterns for sandboxed applications