### PR TITLE
Replace `once_cell::sync::OnceCell` with `std::sync::LazyLock`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Unlicense"
 
 [features]
 default = ["tokio"]
-blocking = ["dep:once_cell"]
+blocking = []
 tokio = ["dep:tokio", "zbus/tokio"]
 async-io = [
     "dep:async-io",
@@ -22,7 +22,6 @@ async-io = [
     "dep:async-executor",
     "dep:futures-lite",
     "dep:futures-channel",
-    "dep:once_cell",
     "zbus/async-io",
 ]
 
@@ -39,7 +38,6 @@ async-lock = { version = "3", optional = true }
 async-executor = { version = "1", optional = true }
 futures-lite = { version = "2", optional = true }
 futures-channel = { version = "0.3", optional = true }
-once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
 smol = "2"

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -22,18 +22,15 @@ mod tokio {
 
     #[cfg(feature = "blocking")]
     pub fn block_on<T>(future: impl Future<Output = T>) -> T {
-        use once_cell::sync::OnceCell;
+        use std::sync::LazyLock;
         use tokio::runtime::Runtime;
-        static RUNTIME: OnceCell<Runtime> = OnceCell::new();
-
-        RUNTIME
-            .get_or_init(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-            })
-            .block_on(future)
+        static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+        });
+        RUNTIME.block_on(future)
     }
 
     pub mod mpsc {
@@ -52,7 +49,7 @@ mod async_io {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use async_executor::Executor;
-    use once_cell::sync::OnceCell;
+    use std::sync::LazyLock;
 
     // Do NOT use async_lock::OnceCell instead
     // the spawn method may be called in async context
@@ -77,11 +74,11 @@ mod async_io {
 
     impl ExecutorState {
         fn get() -> &'static Self {
-            static STATE: OnceCell<ExecutorState> = OnceCell::new();
-            STATE.get_or_init(|| Self {
+            static STATE: LazyLock<ExecutorState> = LazyLock::new(|| ExecutorState {
                 executor: Executor::new(),
                 driver_running: AtomicBool::new(false),
-            })
+            });
+            &STATE
         }
 
         fn kick_driver(&'static self) {


### PR DESCRIPTION
The latter is stable since Rust 1.80.0, which is the current MSRV, and should provide the exact same behaviour, without requiring an external dependency.